### PR TITLE
Handle case of 0 for min or max values

### DIFF
--- a/app/js/graphene.coffee
+++ b/app/js/graphene.coffee
@@ -141,9 +141,9 @@ class Graphene.TimeSeries extends Graphene.GraphiteModel
   process_data: (js)=>
     data = _.map js, (dp)->
       min = d3.min(dp.datapoints, (d) -> d[0])
-      return null unless min
+      return null unless min != undefined 
       max = d3.max(dp.datapoints, (d) -> d[0])
-      return null unless max
+      return null unless max != undefined 
 
       _.each dp.datapoints, (d) -> d[1] = new Date(d[1]*1000)
       return {


### PR DESCRIPTION
The use of "return null unless min" will return null for a value of 0, which can be valid.  d3.min and d3.max return undefined for an empty array, so check for that explicitly.
