### PR TITLE
Fixed bug in TimeSeries when multiple targets have different time spans

### DIFF
--- a/app/js/graphene.coffee
+++ b/app/js/graphene.coffee
@@ -349,7 +349,11 @@ class Graphene.TimeSeriesView extends Backbone.View
     #
     # build dynamic x & y metrics.
     #
-    x = d3.time.scale().domain([data[0].points[0][1], data[0].points[data[0].points.length-1][1]]).range([0, @width])
+    xpoints = _.flatten (d.points.map((p)->p[1]) for d in data)
+    xmin = _.min xpoints, (x)->x.valueOf()
+    xmax = _.max xpoints, (x)->x.valueOf()
+
+    x = d3.time.scale().domain([xmin, xmax]).range([0, @width])
     y = d3.scale.linear().domain([dmin.ymin, dmax.ymax]).range([@height, 0]).nice()
 
     #
@@ -470,22 +474,18 @@ class Graphene.TimeSeriesView extends Backbone.View
 
     vis.selectAll("path.area")
         .data(points)
-        .attr("transform", (d)-> "translate(" + x(d[1][1]) + ")")
         .attr("d", area)
         .transition()
         .ease("linear")
         .duration(@animate_ms)
-        .attr("transform", (d) -> "translate(" + x(d[0][1]) + ")")
 
 
     vis.selectAll("path.line")
         .data(points)
-        .attr("transform", (d)-> "translate(" + x(d[1][1]) + ")")
         .attr("d", line)
         .transition()
         .ease("linear")
         .duration(@animate_ms)
-        .attr("transform", (d) -> "translate(" + x(d[0][1]) + ")")
 
 
 # Barcharts

--- a/app/js/graphene.coffee
+++ b/app/js/graphene.coffee
@@ -75,7 +75,7 @@ class Graphene.GraphiteModel extends Backbone.Model
       success: (js) =>
         console.log("got data.")
         @process_data(js)
-    $.ajax options         
+    $.ajax options
 
   process_data: ()=>
     return null
@@ -118,7 +118,7 @@ class Graphene.DemoTimeSeries extends Backbone.Model
 
   refresh: ()=>
     # clone data - tricks d3/backbone refs
-    @data = _.map @data, (d)-> 
+    @data = _.map @data, (d)->
       d = _.clone(d)
       d.points = _.map(d.points, (p)-> [p[0], p[1]])
       d
@@ -153,16 +153,16 @@ class Graphene.BarChart extends Graphene.GraphiteModel
     console.log 'process data barchart'
     data = _.map js, (dp)->
       min = d3.min(dp.datapoints, (d) -> d[0])
-      return null unless min != undefined 
+      return null unless min != undefined
       max = d3.max(dp.datapoints, (d) -> d[0])
-      return null unless max != undefined 
+      return null unless max != undefined
 
       _.each dp.datapoints, (d) -> d[1] = new Date(d[1]*1000)
       return {
         points: _.reject(dp.datapoints, (d)-> d[0] == null),
         ymin: min,
         ymax: max,
-        label: dp.target 
+        label: dp.target
       }
     data = _.reject data, (d)-> d == null
     @set(data:data)
@@ -171,15 +171,15 @@ class Graphene.TimeSeries extends Graphene.GraphiteModel
   process_data: (js)=>
     data = _.map js, (dp)->
       min = d3.min(dp.datapoints, (d) -> d[0])
-      return null unless min != undefined 
+      return null unless min != undefined
       max = d3.max(dp.datapoints, (d) -> d[0])
-      return null unless max != undefined 
+      return null unless max != undefined
       _.each dp.datapoints, (d) -> d[1] = new Date(d[1]*1000)
       return {
         points: _.reject(dp.datapoints, (d)-> d[0] == null),
         ymin: min,
         ymax: max,
-        label: dp.target 
+        label: dp.target
       }
     data = _.reject data, (d)-> d == null
     @set(data:data)
@@ -471,21 +471,23 @@ class Graphene.TimeSeriesView extends Backbone.View
     vis.selectAll("path.area")
         .data(points)
         .attr("transform", (d)-> "translate(" + x(d[1][1]) + ")")
-        .attr("d", area) 
-        .transition() 
+        .attr("d", area)
+        .transition()
         .ease("linear")
-        .duration(@animate_ms) 
+        .duration(@animate_ms)
         .attr("transform", (d) -> "translate(" + x(d[0][1]) + ")")
 
 
     vis.selectAll("path.line")
         .data(points)
         .attr("transform", (d)-> "translate(" + x(d[1][1]) + ")")
-        .attr("d", line) 
-        .transition() 
+        .attr("d", line)
+        .transition()
         .ease("linear")
-        .duration(@animate_ms) 
+        .duration(@animate_ms)
         .attr("transform", (d) -> "translate(" + x(d[0][1]) + ")")
+
+
 # Barcharts
 class Graphene.BarChartView extends Backbone.View
   tagName: 'div'
@@ -567,4 +569,3 @@ class Graphene.BarChartView extends Backbone.View
     vis.select(".y.axis").call(yAxis)
 
     console.log "done drawing"
-


### PR DESCRIPTION
When drawing a TimeSerieView with multiple targets that have different time spans, the range on the X-axis did not respect the total range of all the series, but only considered the first serie.

This commit should fix that.

Hope this helps!
