### PR TITLE
Renamed "labels" to "num_labels" in time series view initializer 

### DIFF
--- a/app/js/graphene.coffee
+++ b/app/js/graphene.coffee
@@ -310,7 +310,7 @@ class Graphene.TimeSeriesView extends Backbone.View
   initialize: ()->
     @line_height = @options.line_height || 16
     @animate_ms = @options.animate_ms || 500
-    @num_labels = @options.labels || 3
+    @num_labels = @options.num_labels || 3
     @sort_labels = @options.labels_sort || 'desc'
     @display_verticals = @options.display_verticals || false
     @width = @options.width || 400


### PR DESCRIPTION
Initializer now matches spec in README.
