### PR TITLE
Updated documentation and correct the case of the 'ymax' parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ description.
 * `padding` - the kind of padding you need
 * `title` - box title
 * `label_formatter` - and a formatter, as before.
-* `yMax` - the max value for the Y axis. If not specified and the URL has a yMax parameter, the value will be taken from the URL. Otherwise, this option will have precedence.
+* `ymax` - the max value for the Y axis. If not specified and the URL has a yMax parameter, the value will be taken from the URL. Otherwise, this option will have precedence.
 * `ymin` - the min value for the Y axis. 
 
 


### PR DESCRIPTION
I had issues getting the yMax parameter working on TimeSeries graphs. I discovered the documentation indicated the parameter was 'yMax' (as expected by graphite), however graphene expects this parameter to be lower case.
