### PR TITLE
Access models from outside Graphene

### DIFF
--- a/app/js/graphene.coffee
+++ b/app/js/graphene.coffee
@@ -1,6 +1,9 @@
 
 
 class Graphene
+  constructor:->
+    @models = {}
+
   demo:->
     @is_demo = true
 
@@ -18,6 +21,7 @@ class Graphene
         model_opts.refresh_interval = json[k].refresh_interval
         delete json[k].refresh_interval
       ts = new klass(model_opts)
+      @models[k] = ts
 
       _.each json[k], (opts, view)=>
         klass = eval("Graphene.#{view}View")


### PR DESCRIPTION
This change makes it possible to access the models of a dashboard created by `Graphene.build()`.

I came across an issue similar to #51. Exposing the models makes it also possible to do things like changing the `source` attribute dynamically and then call `Graphene.GraphiteModel.refresh()` to refresh the data immediately.
